### PR TITLE
Use the 11ty configuration API to ignore partials

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -44,15 +44,14 @@ module.exports = (eleventyConfig) => {
   // Recognize Sass as a "template languages"
   eleventyConfig.addTemplateFormats("scss");
 
+  // Ignore scss files starting with underscore
+  eleventyConfig.ignores.add("**/_*.scss");
+
   // Compile Sass and process with LightningCSS
   eleventyConfig.addExtension("scss", {
     outputFileExtension: "css",
     compile: async function (inputContent, inputPath) {
       let parsed = path.parse(inputPath);
-      if (parsed.name.startsWith("_")) {
-        return;
-      }
-
       let targets = browserslistToTargets(browserslist(browserslistTargets));
 
       let result = sass.compileString(inputContent, {

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Also respects either your package.json `browserslist` or a `.browserslistrc`, ot
 
 Review [LightningCSS docs](https://lightningcss.dev/transpilation.html) to learn more about what future CSS features are supported via syntax lowering, including color functions, media query ranges, logical properties, and more.
 
-> **Note**
+> [!NOTE]
 > Requires Eleventy v2 - review [upgrade considerations](https://11ty.rocks/posts/new-features-upgrade-considerations-eleventy-version-2/) if applying to an existing project.
 
 <small>Interested in using LightningCSS in 11ty without Sass? You'll want my [Eleventy LightningCSS plugin](https://github.com/5t3ph/eleventy-plugin-lightningcss) instead!</small>
@@ -29,8 +29,8 @@ module.exports = (eleventyConfig) => {
   eleventyConfig.addPlugin(eleventySass);
 };
 ```
-
-⚠️ **Important**: The files will end up in `collections.all` and appear in places like RSS feeds where you may be using the "all" collection. To prevent that, [a temporary workaround](https://github.com/11ty/eleventy/discussions/2850#discussioncomment-5254892) is to create a directory data file to exclude your Sass files.
+> [!IMPORTANT]
+> The files will end up in `collections.all` and appear in places like RSS feeds where you may be using the "all" collection. To prevent that, [a temporary workaround](https://github.com/11ty/eleventy/discussions/2850#discussioncomment-5254892) is to create a directory data file to exclude your Sass files.
 
 Place the following in the directory containing your Sass files. As an example, for a directory called `css` the file would be called `css/css.json`:
 
@@ -42,7 +42,9 @@ Place the following in the directory containing your Sass files. As an example, 
 
 Then, write your Sass using any organization pattern you like as long as it lives within your defined [Eleventy input directory](https://www.11ty.dev/docs/config/#input-directory).
 
-> **Note**
+As per Sass conventions, you can name your scss files with a leading underscore (`_`) to mark them as partials. Partials will not be generated into CSS files.
+
+> [!NOTE]
 > If you are already using PostCSS or Parcel, you will be doubling efforts with this plugin and should not add it.
 
 ## How does it work?


### PR DESCRIPTION
Instead of manually checking the file name if it starts with an underscore, I've used the 11ty configuration API to ignore those files.
I've also added a note about partials to README and converted alerts to use the new alert syntax.